### PR TITLE
Issue #122 : Homepage: Carousel doesn't show all the company's when navigating to the left

### DIFF
--- a/src/classes/Carousel.js
+++ b/src/classes/Carousel.js
@@ -87,7 +87,7 @@ export default class {
                 if (direction === 'right') {
                     next = (i + 1 < this.slides.length) ? this.slides[i+1] : this.slides[0];
                 } else {
-                    next = (i - 1 > 0) ? this.slides[i-1] : this.slides[this.slides.length-1];
+                    next = (i - 1 >= 0) ? this.slides[i-1] : this.slides[this.slides.length-1];
                 }
             }
         }


### PR DESCRIPTION
The first company was skipped when navigating to the left in the carousel